### PR TITLE
Fix assignment of mp_stacks_magnificPopup

### DIFF
--- a/includes/js/mp-stacks-front-end.js
+++ b/includes/js/mp-stacks-front-end.js
@@ -28,7 +28,7 @@ jQuery(document).ready(function($){
 
 	}
 
-	mp_stacks_magnificPopup = $.magnificPopup.instance;
+	mp_stacks_magnificPopup = $.magnificPopup;
 
 	/**
 	 * Any Stacks that aren't added as Shortcodes (widgets, other, etc) need to have their CSS moved from the footer into the page <head>


### PR DESCRIPTION
Attempting to edit any of the bricks in my stacks currently results in a 
```
Uncaught TypeError: Cannot read property 'open' of null
```
error on the `mp_stacks_magnificPopup` variable. A little bit of digging in the console revealed that the `instance` property on `$.magnificPopup` was always null, but the `$.magnificPopup` itself has the `open()` and `close()` functions we need.

Hopefully this is a genuine fix and not just some bizarre quirk that I am seeing.